### PR TITLE
Fix php74 errors

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -2,12 +2,12 @@
 
 namespace Tkui;
 
-use Stringable;
-
 /**
  * Contract for graphic images.
+ *
+ * TODO: extends Stringable
  */
-interface Image extends Stringable
+interface Image
 {
     public function width(): int;
 

--- a/src/Widgets/TreeView/Column.php
+++ b/src/Widgets/TreeView/Column.php
@@ -64,7 +64,7 @@ class Column
         return $this->header;
     }
 
-    public static function create(string $id, string $header): static
+    public static function create(string $id, string $header): self
     {
         return new static($id, new Header($header));
     }

--- a/src/Widgets/TreeView/Item.php
+++ b/src/Widgets/TreeView/Item.php
@@ -76,7 +76,7 @@ class Item
         return $this->options;
     }
 
-    public static function values(array $values): static
+    public static function values(array $values): self
     {
         return new static($values);
     }

--- a/src/Widgets/TreeView/TreeView.php
+++ b/src/Widgets/TreeView/TreeView.php
@@ -63,19 +63,19 @@ class TreeView extends ScrollableTtkWidget
         ]);
     }
 
-    public function onSelect(callable $callback): static
+    public function onSelect(callable $callback): self
     {
         $this->bind('<<TreeviewSelect>>', fn () => $callback($this->selected(), $this));
         return $this;
     }
 
-    public function onOpen(callable $callback): static
+    public function onOpen(callable $callback): self
     {
         $this->bind('<<TreeviewOpen>>', fn () => $callback($this));
         return $this;
     }
 
-    public function onClose(callable $callback): static
+    public function onClose(callable $callback): self
     {
         $this->bind('<<TreeviewClose>>', fn () => $callback($this));
         return $this;
@@ -101,21 +101,21 @@ class TreeView extends ScrollableTtkWidget
         $this->call('heading', $column->id, '-text', $column->header()->text);
     }
 
-    public function add(Item $item, string $parentId = ''): static
+    public function add(Item $item, string $parentId = ''): self
     {
         $args = $item->options()->asStringArray();
         $this->call('insert', $parentId ?: '{}', 'end', ...$args);
         return $this;
     }
 
-    public function delete(Item ...$items): static
+    public function delete(Item ...$items): self
     {
         $ids = array_map(fn (Item $item) => $item->id, $items);
         $this->call('delete', ...$ids);
         return $this;
     }
 
-    public function focusItem(Item $item): static
+    public function focusItem(Item $item): self
     {
         $this->call('focus', $item->id);
         return $this;
@@ -171,7 +171,7 @@ class TreeView extends ScrollableTtkWidget
     /**
      * Sets the viewport to the specified item.
      */
-    public function seeItemId(string $itemId): static
+    public function seeItemId(string $itemId): self
     {
         $this->call('see', $itemId);
         return $this;

--- a/tests/Widgets/TextTest.php
+++ b/tests/Widgets/TextTest.php
@@ -8,6 +8,7 @@ use Tkui\Widgets\Text\Range;
 use Tkui\Widgets\Text\Text;
 use Tkui\Widgets\Text\TextIndex;
 use PHPUnit\Framework\MockObject\MockObject;
+use Tkui\TclTk\TkImage;
 
 class TextTest extends TestCase
 {
@@ -174,7 +175,9 @@ class TextTest extends TestCase
         ]);
 
         /** @var Image|MockObject */
-        $image = $this->createMock(Image::class);
+        // FIXME: Since Image doesn't have Stringable TkImage is used here, after switching
+        // to PHP8 it must be changed to Image interface instead of TkImage.
+        $image = $this->createMock(TkImage::class);
         $image->expects($this->once())
               ->method('__toString')
               ->willReturn('i0')


### PR DESCRIPTION
buttons, menu, text, treeview demos are not working with PHP 7.4 which is minimal requirement in `composer.json`.
This PR removes all the PHP 8 new feature to be compatible with 7.4
Mentioned here: https://github.com/skoro/php-tkui/issues/4#issuecomment-1294352704