### PR TITLE
fix: Update "Getting Started" commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Clone this repository and try out the demos:
 ```sh
 git clone https://github.com/skoro/php-tkui.git php-tkui
 cd php-tkui
+composer install
 php demos/buttons.php
 ```
 


### PR DESCRIPTION
I just added a missing command to "Getting Started" section.