### PR TITLE
Adding Tcl list variables

### DIFF
--- a/src/TclTk/Interp.php
+++ b/src/TclTk/Interp.php
@@ -102,6 +102,18 @@ class Interp
     }
 
     /**
+     * Creates a Tcl list variable.
+     */
+    public function createListVariable(string $varName): ListVariable
+    {
+        $this->debug('createListVariable', [
+            'varName' => $varName,
+        ]);
+
+        return new ListVariable($this, $varName);
+    }
+
+    /**
      * Gets the interp eval result as a list of strings.
      */
     public function getListResult(): array

--- a/src/TclTk/ListVariable.php
+++ b/src/TclTk/ListVariable.php
@@ -35,4 +35,10 @@ class ListVariable
     {
         return $this->interp->tcl()->getListLength($this->interp, $this->listObj);
     }
+
+    public function index(int $i)
+    {
+        $result = $this->interp->tcl()->getListIndex($this->interp, $this->listObj, $i);
+        return $this->interp->tcl()->getStringFromObj($result);
+    }
 }

--- a/src/TclTk/ListVariable.php
+++ b/src/TclTk/ListVariable.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Tkui\TclTk;
+
+use FFI\CData;
+
+class ListVariable
+{
+    private Interp $interp;
+    private CData $listObj;
+    private string $name;
+
+    public function __construct(Interp $interp, string $name)
+    {
+        $this->interp = $interp;
+        $this->name = $name;
+        $this->listObj = $interp->tcl()->createListObj();
+        $interp->tcl()->setVar($interp, $name, null, $this->listObj);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function append($value): self
+    {
+        $this->interp->tcl()->addListElement($this->interp, $this->listObj, $value);
+        return $this;
+    }
+}

--- a/src/TclTk/ListVariable.php
+++ b/src/TclTk/ListVariable.php
@@ -23,9 +23,16 @@ class ListVariable
         return $this->name;
     }
 
-    public function append($value): self
+    public function append(...$values): self
     {
-        $this->interp->tcl()->addListElement($this->interp, $this->listObj, $value);
+        foreach ($values as $value) {
+            $this->interp->tcl()->addListElement($this->interp, $this->listObj, $value);
+        }
         return $this;
+    }
+
+    public function count(): int
+    {
+        return $this->interp->tcl()->getListLength($this->interp, $this->listObj);
     }
 }

--- a/src/TclTk/Tcl.php
+++ b/src/TclTk/Tcl.php
@@ -231,6 +231,15 @@ class Tcl
         }
     }
 
+    public function getListLength(Interp $interp, CData $listObj): int
+    {
+        $len = FFI::new('int');
+        if ($this->ffi->Tcl_ListObjLength($interp->cdata(), $listObj, FFI::addr($len)) != self::TCL_OK) {
+            throw new TclInterpException($interp, 'ListObjLength');
+        }
+        return $len->cdata;
+    }
+
     /**
      * Converts a PHP value to Tcl Obj structure.
      *

--- a/src/headers/tcl86.h
+++ b/src/headers/tcl86.h
@@ -86,6 +86,7 @@ Tcl_Obj *Tcl_NewByteArrayObj(const unsigned char *bytes, int length);
 Tcl_Obj *Tcl_NewDoubleObj(double doubleValue);
 Tcl_Obj *Tcl_NewIntObj(int intValue);
 Tcl_Obj *Tcl_NewStringObj(const char *bytes, int length);
+Tcl_Obj *Tcl_NewListObj(int objc, Tcl_Obj *const objv[]);
 
 const char *Tcl_GetVar(Tcl_Interp *interp, const char *varName, int flags);
 const char *Tcl_GetVar2(Tcl_Interp *interp, const char *part1, const char *part2, int flags);

--- a/tests/Tcl/ListVariableTest.php
+++ b/tests/Tcl/ListVariableTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Tkui\Tests\Tcl;
+
+use Tkui\Tests\TclInterp;
+use Tkui\Tests\TestCase;
+
+class ListVariableTest extends TestCase
+{
+    use TclInterp;
+
+    /** @test */
+    public function it_can_create_list_variable_in_tcl_interp(): void
+    {
+        $this->interp->createListVariable('test');
+        $result = $this->interp->eval('set test');
+        
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function it_can_get_list_length(): void
+    {
+        $var = $this->interp->createListVariable('test');
+        $values = range(1, random_int(99, 99999));
+        $var->append(...$values);
+
+        $this->assertEquals(count($values), $var->count());
+    }
+}

--- a/tests/Tcl/ListVariableTest.php
+++ b/tests/Tcl/ListVariableTest.php
@@ -27,4 +27,14 @@ class ListVariableTest extends TestCase
 
         $this->assertEquals(count($values), $var->count());
     }
+
+    /** @test */
+    public function it_can_get_string_from_list_index(): void
+    {
+        $var = $this->interp->createListVariable('test');
+        $var->append('val1', 'val2', 'val3');
+        $this->assertEquals('val1', $var->index(0));
+        $this->assertEquals('val2', $var->index(1));
+        $this->assertEquals('val3', $var->index(2));
+    }
 }


### PR DESCRIPTION
This PR adds Tcl list variables. It supports adding, getting values and get count of elements.
Usage is following:
```php
$argv = $interp->createListVariable('argv');
$argv->append('-name', 'value1');
```