### PR TITLE
Allowing any version of psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-ffi": "*",
         "ext-spl": "*",
         "ext-mbstring": "*",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "monolog/monolog": "^2.2",
         "vlucas/phpdotenv": "^5.5"
     },


### PR DESCRIPTION
Locking psr/log in `^1.1` prevents the instalation of this library alongisde other projects that require newer versions. Since all the methods used in this project exist in all versions of the PSR, we any version can be used by it.